### PR TITLE
fix: drop stale holding room connections and bump to 0.1.5

### DIFF
--- a/danmakus-core/src/core/AccountApiClient.test.ts
+++ b/danmakus-core/src/core/AccountApiClient.test.ts
@@ -19,7 +19,9 @@ describe('AccountApiClient', () => {
 
     expect(result).toEqual({
       configTag: '"config-tag"',
-      assignmentTag: 'assignment-tag'
+      assignmentTag: 'assignment-tag',
+      clientsTag: null,
+      recordingTag: null
     });
   });
 

--- a/danmakus-core/src/core/DanmakuClient.priority.test.ts
+++ b/danmakus-core/src/core/DanmakuClient.priority.test.ts
@@ -18,7 +18,7 @@ describe("DanmakuClient room connect queue", () => {
 
     try {
       client.isRunning = true;
-      client.queueRoomConnect(6154037, "high");
+      client.holdingRoomCoordinator.queueRoomConnect(6154037, "high");
       expect(delays[0]).toBe(0);
     } finally {
       globalThis.setTimeout = originalSetTimeout;
@@ -55,7 +55,7 @@ describe("DanmakuClient room pull flow", () => {
       return true;
     };
 
-    await client.heartbeatRuntimeState();
+    await client.runtimeSync.heartbeatRuntimeState();
 
     expect(refreshCalls).toEqual([
       {
@@ -97,7 +97,7 @@ describe("DanmakuClient room pull flow", () => {
       return true;
     };
 
-    await client.heartbeatRuntimeState();
+    await client.runtimeSync.heartbeatRuntimeState();
 
     expect(refreshCalls).toEqual([]);
   });
@@ -157,10 +157,52 @@ describe("DanmakuClient room pull flow", () => {
     expect(client.holdingRoomIds).toEqual([102, 103]);
     expect(client._updatedRooms).toEqual([102, 103]);
     expect(client.connections.has(101)).toBe(false);
-    expect(client.connections.has(999)).toBe(true);
-    expect(closedRooms).toEqual([101]);
+    expect(client.connections.has(999)).toBe(false);
+    expect(closedRooms).toEqual([101, 999]);
     expect(client._connectionsUpdated).toBe(true);
     expect(client._synced).toBe(true);
+  });
+
+  it("abandons an in-flight connect when the room is no longer desired", async () => {
+    const client: any = new DanmakuClient({
+      runtimeUrl: "https://example.com/api/v2/core-runtime",
+      maxConnections: 5,
+      requestServerRooms: true,
+      streamers: [],
+    });
+
+    let resolveConnectionOptions: ((value: unknown) => void) | undefined;
+    let factoryCallCount = 0;
+    client.isRunning = true;
+    client._desiredRooms = [{ roomId: 4455, priority: "server" }];
+    client.statusManager = {
+      getRoomsToConnect: () => client._desiredRooms,
+    };
+    client.resolveLiveWsConnectionOptions = () => new Promise((resolve) => {
+      resolveConnectionOptions = resolve;
+    });
+    client.liveWsConnectionFactory = async () => {
+      factoryCallCount += 1;
+      return {
+        addEventListener: () => undefined,
+        close: () => undefined,
+      };
+    };
+    client.syncRuntimeState = async () => undefined;
+
+    const connecting = client.connectToRoom(4455, "server");
+    client._desiredRooms = [];
+    resolveConnectionOptions?.({
+      roomId: 4455,
+      address: "wss://example.com/sub",
+      key: "key-4455",
+      uid: 1,
+      protover: 3,
+    });
+    await connecting;
+
+    expect(factoryCallCount).toBe(0);
+    expect(client.connections.has(4455)).toBe(false);
   });
 
   it("forces a room request during reconnect even when cooldown is active and desiredCount is zero", async () => {
@@ -239,7 +281,7 @@ describe("DanmakuClient room pull flow", () => {
       }),
     };
 
-    await client.refreshRecordingList(true);
+    await client.controlState.refreshRecordingList(true);
 
     expect(client.recordingRoomIds).toEqual([2233]);
     expect(updatedRooms).toEqual([[2233]]);
@@ -257,6 +299,13 @@ describe("DanmakuClient room pull flow", () => {
 
     let factoryCallCount = 0;
     client.isRunning = true;
+    client._desiredRooms = [
+      { roomId: 1001, priority: "high" },
+      { roomId: 1002, priority: "server" },
+    ];
+    client.statusManager = {
+      getRoomsToConnect: () => client._desiredRooms,
+    };
     client.resolveLiveWsConnectionOptions = async (roomId: number) => ({
       roomId: 5566,
       address: "wss://example.com/sub",

--- a/danmakus-core/src/core/DanmakuClient.ts
+++ b/danmakus-core/src/core/DanmakuClient.ts
@@ -586,7 +586,13 @@ export class DanmakuClient extends EventEmitter {
       this.logger.info(`正在连接到房间 ${roomId} (优先级: ${priority})...`);
 
       const connectionOptions = await this.resolveLiveWsConnectionOptions(roomId);
-      if (generation !== this.runtimeGeneration || !this.isRunning || this.isStopping || this.connections.has(roomId)) {
+      if (
+        generation !== this.runtimeGeneration
+        || !this.isRunning
+        || this.isStopping
+        || this.connections.has(roomId)
+        || !this.isRoomStillDesired(roomId)
+      ) {
         return;
       }
       const targetRoomId = typeof connectionOptions.roomId === 'number' && connectionOptions.roomId > 0
@@ -618,7 +624,12 @@ export class DanmakuClient extends EventEmitter {
       const liveWS = this.liveWsConnectionFactory
         ? await this.liveWsConnectionFactory(targetRoomId, roomConfig)
         : new LiveWS(targetRoomId, liveOptions);
-      if (generation !== this.runtimeGeneration || !this.isRunning || this.isStopping) {
+      if (
+        generation !== this.runtimeGeneration
+        || !this.isRunning
+        || this.isStopping
+        || !this.isRoomStillDesired(roomId)
+      ) {
         try {
           liveWS.close();
         } catch {
@@ -972,6 +983,10 @@ export class DanmakuClient extends EventEmitter {
    */
   getConnectedRooms(): number[] {
     return Array.from(this.connections.keys());
+  }
+
+  private isRoomStillDesired(roomId: number): boolean {
+    return this.statusManager ? this.holdingRoomCoordinator.isRoomStillDesired(roomId) : true;
   }
 
   private findConnectionByResolvedRoomId(resolvedRoomId: number, excludeRoomId?: number): ConnectionInfo | undefined {

--- a/danmakus-core/src/core/DanmakuHoldingRoomCoordinator.ts
+++ b/danmakus-core/src/core/DanmakuHoldingRoomCoordinator.ts
@@ -383,6 +383,9 @@ export class DanmakuHoldingRoomCoordinator {
     const next = Array.from(new Set(result.holdingRooms.filter((roomId) => Number.isFinite(roomId) && roomId > 0)));
     const removedRooms = previous.filter((roomId) => !next.includes(roomId));
     const addedRooms = next.filter((roomId) => !previous.includes(roomId));
+    const zombieConnectedRooms = Array.from(this.context.getConnections().keys())
+      .filter((roomId) => Number.isFinite(roomId) && roomId > 0 && !next.includes(roomId));
+    const roomsToDisconnect = Array.from(new Set([...removedRooms, ...zombieConnectedRooms]));
 
     this.context.setHoldingRoomIds(next);
     this.context.setNextHoldingRoomRequestAt(
@@ -398,7 +401,7 @@ export class DanmakuHoldingRoomCoordinator {
       this.context.setLastRoomAssigned(lastAssignedRoom);
     }
 
-    for (const roomId of removedRooms) {
+    for (const roomId of roomsToDisconnect) {
       this.removeQueuedRoomConnect(roomId);
       this.context.disconnectFromRoom(roomId);
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "danmakus-client",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "danmakus-client"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "danmakus-client"
-version = "0.1.4"
+version = "0.1.5"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "danmakus-client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "com.danmakus.client",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- drop stale and zombie holding-room connections when room-pull assignments change
- avoid finishing in-flight connects for rooms that are no longer desired
- bump desktop package version to 0.1.5 and align Tauri metadata

## Verification
- un test in danmakus-core
- un run build in repo root